### PR TITLE
Adding SSR Support

### DIFF
--- a/.github/workflows/deploy-old-showcase.disabled.yml
+++ b/.github/workflows/deploy-old-showcase.disabled.yml
@@ -41,12 +41,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24.16.0'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 11.21.0
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,13 +33,13 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24.16.0'
           # cache: pnpm
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 11.21.0
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,13 +24,13 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 11.21.0
           run_install: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24.16.0'
           cache: pnpm
 
       - name: Install dependencies
@@ -51,13 +51,13 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 11.21.0
           run_install: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24.16.0'
           cache: pnpm
 
       - name: Install dependencies
@@ -91,13 +91,13 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 11.21.0
           run_install: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24.16.0'
           cache: pnpm
 
       - name: Install dependencies
@@ -146,13 +146,13 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 11.21.0
           run_install: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24.16.0'
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **SSR Support**: The package is now fully server-side rendering safe and can be used in Nuxt and other Vue SSR setups without `document is not defined` errors
+- **`isClient` Export**: New exported flag to detect a browser environment from consuming code
+- **Docs**: New "SSR & Nuxt" guide page
+- **Package Exports**: Added the shorter `@borstihd/vue-custom-tooltip/style.css` entry (the previous `/dist/style.css` path keeps working)
+
+### Fixed
+
+- **Theme Injection**: `injectThemeStyles()` and `setTooltipGlobalTheme()` no longer touch `document` during SSR; styles are injected once the client takes over
+- **Teleport**: The tooltip teleport is only rendered after mount, preventing SSR errors and hydration mismatches
+- **Hydration**: Tooltip ARIA IDs now use Vue's `useId()` instead of `Math.random()`, so server and client markup match
+- **Directive**: `v-tooltip` provides `getSSRProps` and guards its shared app initialization against non-browser environments
+- **Positioning**: `window` access in position calculation and show/hide timers is guarded for non-browser environments
+
 ### Changed
 
+- **Internal**: `injectThemeStyles()` moved into its own module to resolve a circular import between the entry point and the global config (still exported from the package root)
+- **Package**: Declared `sideEffects` so bundlers can tree-shake more aggressively while keeping CSS imports intact
 - **Dependencies**: Updated dev dependencies to their latest major versions (Vite 8, Vitest 4, ESLint 10, TypeScript 6, vite-plugin-dts 5) and migrated the affected build configs
 
 ## [1.7.1] - 2026-01-20

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A flexible and accessible Vue 3 tooltip component and directive with TypeScript 
 - ⏱️ **Configurable Delays**: Custom show/hide delays
 - 🎮 **Programmatic Control**: Show, hide, and toggle tooltips programmatically
 - 🌙 **Theme Support**: Built-in dark mode and theme presets
+- 🖥️ **SSR Ready**: Works out of the box with Nuxt and other Vue SSR setups
 
 ## Installation
 
@@ -78,6 +79,7 @@ For comprehensive guides, examples, and API reference, visit the [full documenta
 - **[Directive Usage](https://borstihd.github.io/vue-custom-tooltip/guide/directive-usage)** - Directive modifiers and options
 - **[Global Configuration](https://borstihd.github.io/vue-custom-tooltip/guide/global-config)** - Set defaults for all tooltips
 - **[Themes](https://borstihd.github.io/vue-custom-tooltip/themes/overview)** - Built-in themes and customization
+- **[SSR & Nuxt](https://borstihd.github.io/vue-custom-tooltip/guide/ssr)** - Server-side rendering setup
 - **[Examples](https://borstihd.github.io/vue-custom-tooltip/examples/)** - Interactive examples and demos
 
 ## Browser Support

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -72,6 +72,7 @@ export default defineConfig({
           text: 'Advanced',
           items: [
             { text: 'Accessibility', link: '/guide/accessibility' },
+            { text: 'SSR & Nuxt', link: '/guide/ssr' },
           ],
         },
       ],

--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -1,0 +1,103 @@
+# SSR & Nuxt
+
+`@borstihd/vue-custom-tooltip` is fully server-side rendering (SSR) safe. The package can be imported and installed in a universal (server + client) context without touching `document`, `window` or any other browser-only global.
+
+## How it works
+
+Tooltips are inherently interactive: they only become visible after a hover, focus or click. There is therefore nothing meaningful to render on the server, and the library takes advantage of that:
+
+- **The trigger is server-rendered.** In component mode the `.tooltip-wrapper` / `.tooltip-trigger` markup and your default slot are part of the SSR output, so layout and content stay intact.
+- **The tooltip itself is client-only.** The `<Teleport to="body">` is rendered only after `onMounted`, which avoids both the `document.body` lookup on the server and hydration mismatches.
+- **IDs are hydration-safe.** ARIA IDs come from Vue's `useId()`, so server and client agree on the same value.
+- **Theme CSS injection is a no-op on the server.** `injectThemeStyles()` returns early outside the browser; the stylesheet is injected once the client takes over.
+- **The directive ships `getSSRProps`.** `v-tooltip` adds no attributes to the server-rendered markup and initializes its shared app lazily in the `mounted` hook.
+
+You can query the environment yourself via the exported `isClient` flag:
+
+```ts
+import { isClient } from '@borstihd/vue-custom-tooltip'
+```
+
+## Nuxt setup
+
+Create a **universal** plugin (no `.client` suffix needed):
+
+```ts
+// plugins/tooltip.ts
+import { VueCustomTooltip } from '@borstihd/vue-custom-tooltip'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.use(VueCustomTooltip, {
+    theme: 'default',
+    globalConfig: {
+      position: 'auto',
+      trigger: 'both',
+      showDelay: 100,
+    },
+  })
+})
+```
+
+Register the stylesheet globally in `nuxt.config.ts`:
+
+```ts
+export default defineNuxtConfig({
+  css: ['@borstihd/vue-custom-tooltip/style.css'],
+})
+```
+
+::: tip Older path still works
+`@borstihd/vue-custom-tooltip/dist/style.css` remains available for backwards compatibility.
+:::
+
+That's it — use the component and the directive anywhere, including inside server-rendered pages:
+
+```vue
+<template>
+  <Tooltip content="Rendered on the server, shown on the client">
+    <button>Hover me</button>
+  </Tooltip>
+
+  <button v-tooltip.top="'Works too'">
+    Hover me
+  </button>
+</template>
+```
+
+## Troubleshooting
+
+### `document is not defined`
+
+Make sure you are on version `1.8.0` or newer. Earlier releases injected theme styles during `app.use()` without guarding for the server.
+
+### Nuxt cannot resolve the package
+
+If your Nitro build complains about the ESM output, add the package to `build.transpile`:
+
+```ts
+export default defineNuxtConfig({
+  build: {
+    transpile: ['@borstihd/vue-custom-tooltip'],
+  },
+})
+```
+
+### `<ClientOnly>` is not required
+
+You do not need to wrap tooltips in `<ClientOnly>`. Doing so would also remove the trigger element from the server-rendered HTML, which hurts SEO and causes layout shift.
+
+## Other SSR frameworks
+
+The same guarantees apply to any Vue SSR setup (Vite SSR, Quasar SSR, custom `renderToString` servers). Install the plugin on the app instance you pass to `renderToString()`:
+
+```ts
+import { VueCustomTooltip } from '@borstihd/vue-custom-tooltip'
+import { createSSRApp } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import App from './App.vue'
+
+const app = createSSRApp(App)
+app.use(VueCustomTooltip)
+
+const html = await renderToString(app)
+```

--- a/package.json
+++ b/package.json
@@ -24,12 +24,16 @@
     "accessibility",
     "a11y"
   ],
+  "sideEffects": [
+    "**/*.css"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/vue-custom-tooltip.es.js",
       "require": "./dist/vue-custom-tooltip.umd.js"
     },
+    "./style.css": "./dist/vue-custom-tooltip.css",
     "./dist/style.css": "./dist/vue-custom-tooltip.css"
   },
   "main": "./dist/vue-custom-tooltip.umd.js",

--- a/src/__tests__/Ssr.spec.ts
+++ b/src/__tests__/Ssr.spec.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createSSRApp, defineComponent, h } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import Tooltip from '@/components/tooltip/Tooltip.vue'
+import { resetTooltipGlobalConfig } from '@/config/index'
+import { vTooltip, VueCustomTooltip } from '@/index'
+import { isClient } from '@/utils/ssr'
+
+describe('sSR rendering', () => {
+  beforeEach(() => {
+    resetTooltipGlobalConfig()
+  })
+
+  it('detects a non-browser environment', () => {
+    expect(isClient).toBe(false)
+    expect(typeof window).toBe('undefined')
+    expect(typeof document).toBe('undefined')
+  })
+
+  it('renders the component mode trigger without touching the DOM', async () => {
+    const app = createSSRApp({
+      render: () => h(Tooltip, { content: 'Hello' }, { default: () => h('button', 'Trigger') }),
+    })
+
+    const html = await renderToString(app)
+
+    expect(html).toContain('tooltip-wrapper')
+    expect(html).toContain('Trigger')
+    expect(html).not.toContain('custom-tooltip')
+  })
+
+  it('does not render a teleport when the tooltip is initially visible', async () => {
+    const app = createSSRApp({
+      render: () => h(Tooltip, { content: 'Hello', modelValue: true }, { default: () => h('button', 'Trigger') }),
+    })
+
+    const html = await renderToString(app)
+
+    expect(html).not.toContain('teleport')
+    expect(html).not.toContain('custom-tooltip')
+  })
+
+  it('installs the plugin with a theme without accessing document', async () => {
+    const app = createSSRApp({
+      render: () => h(Tooltip, { content: 'Themed' }, { default: () => h('span', 'Trigger') }),
+    })
+    app.use(VueCustomTooltip, {
+      theme: 'vuetify',
+      globalConfig: { position: 'top', showDelay: 0 },
+    })
+
+    await expect(renderToString(app)).resolves.toContain('Trigger')
+  })
+
+  it('renders elements using the directive without errors', async () => {
+    const Host = defineComponent({
+      directives: { tooltip: vTooltip },
+      template: '<button v-tooltip="\'Directive tooltip\'">Directive trigger</button>',
+    })
+
+    const html = await renderToString(createSSRApp(Host))
+
+    expect(html).toContain('Directive trigger')
+    expect(html).not.toContain('data-tooltip-directive-container')
+  })
+})

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -2,6 +2,11 @@ import { beforeAll } from 'vitest'
 
 // Mock window.matchMedia
 beforeAll(() => {
+  // Skipped for tests running in the node environment (SSR tests)
+  if (typeof window === 'undefined') {
+    return
+  }
+
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
     value: (query: string) => ({

--- a/src/components/DarkModeToggle.vue
+++ b/src/components/DarkModeToggle.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, watchEffect } from 'vue'
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 export type Appearance = 'auto' | 'light' | 'dark'
 
@@ -54,21 +54,24 @@ watch(currentTheme, (newTheme) => {
 })
 
 // Listen for auto theme changes
-watchEffect((onCleanup) => {
+let mediaQuery: MediaQueryList | null = null
+
+function handleChange() {
+  if (currentTheme.value === 'auto') {
+    setAppearance('auto')
+  }
+}
+
+onMounted(() => {
   initTheme()
 
-  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-  const handleChange = () => {
-    if (currentTheme.value === 'auto') {
-      setAppearance('auto')
-    }
-  }
-
+  mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
   mediaQuery.addEventListener('change', handleChange)
+})
 
-  onCleanup(() => {
-    mediaQuery.removeEventListener('change', handleChange)
-  })
+onBeforeUnmount(() => {
+  mediaQuery?.removeEventListener('change', handleChange)
+  mediaQuery = null
 })
 </script>
 

--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -41,7 +41,7 @@
  */
 
 import type { TooltipExposed, TooltipProps, TooltipSlots } from '../../types/tooltip'
-import { computed, nextTick, useSlots, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, onMounted, ref, useId, useSlots, useTemplateRef, watch } from 'vue'
 
 import {
   useExternalTrigger,
@@ -51,6 +51,7 @@ import {
   useTooltipVisibility,
 } from '../../composables'
 import { getTooltipGlobalThemeRef } from '../../config/index'
+import { isClient } from '../../utils/ssr'
 
 /**
  * Generic Tooltip Component
@@ -89,15 +90,16 @@ defineSlots<{
 }>()
 
 // Generate unique ID for accessibility
-function generateTooltipId() {
-  const randomPart = Math.random().toString(36).substring(2, 9)
-  return `tooltip-${randomPart}`
-}
-
+// useId() is SSR-safe and stays stable across server render and hydration
 const slots = useSlots()
 
-// Generate unique ID for ARIA attributes
-const tooltipId = generateTooltipId()
+const tooltipId = `tooltip-${useId()}`
+
+// The teleported tooltip is only rendered on the client to avoid SSR/hydration issues
+const isMounted = ref(false)
+onMounted(() => {
+  isMounted.value = true
+})
 
 // Element refs
 const internalTriggerElement = useTemplateRef<HTMLElement>('internalTrigger')
@@ -236,12 +238,14 @@ const tooltipClasses = computed(() => [
 
 // Watch for position changes to recalculate
 watch([isVisible, effectivePosition], async () => {
-  if (isVisible.value) {
-    await nextTick()
-    // Wait for the browser to render the tooltip with proper dimensions
-    await new Promise(resolve => requestAnimationFrame(resolve))
-    calculatePosition()
+  if (!isClient || !isVisible.value) {
+    return
   }
+
+  await nextTick()
+  // Wait for the browser to render the tooltip with proper dimensions
+  await new Promise(resolve => requestAnimationFrame(resolve))
+  calculatePosition()
 })
 
 // Setup event listeners and ARIA attributes for external trigger element (directive mode)
@@ -281,7 +285,7 @@ useExternalTrigger(
   </div>
 
   <!-- Custom tooltip -->
-  <Teleport to="body">
+  <Teleport v-if="isMounted" to="body">
     <Transition name="tooltip-fade">
       <div
         v-if="isVisible"

--- a/src/composables/useTooltipPosition.ts
+++ b/src/composables/useTooltipPosition.ts
@@ -1,5 +1,6 @@
 import type { ComputedRef, Ref } from 'vue'
 import { ref } from 'vue'
+import { isClient } from '../utils/ssr'
 
 export type TooltipPosition = 'top' | 'bottom' | 'left' | 'right' | 'auto'
 export type ActualPosition = 'top' | 'bottom' | 'left' | 'right'
@@ -154,6 +155,9 @@ export function useTooltipPosition(
    * Calculates and updates the tooltip position and styles
    */
   function calculate() {
+    if (!isClient)
+      return
+
     if (!triggerElement.value || !tooltipElement.value)
       return
 

--- a/src/composables/useTooltipVisibility.ts
+++ b/src/composables/useTooltipVisibility.ts
@@ -19,8 +19,8 @@ export function useTooltipVisibility(
   const _isVisible = ref(false)
   const isVisible = computed(() => _isVisible.value)
 
-  let showTimeout: number | null = null
-  let hideTimeout: number | null = null
+  let showTimeout: ReturnType<typeof setTimeout> | null = null
+  let hideTimeout: ReturnType<typeof setTimeout> | null = null
 
   /**
    * Clears any pending show/hide timeouts
@@ -44,7 +44,7 @@ export function useTooltipVisibility(
       return
 
     clearTimeouts()
-    showTimeout = window.setTimeout(async () => {
+    showTimeout = setTimeout(async () => {
       _isVisible.value = true
       await nextTick()
       // Wait for the browser to render the tooltip with proper dimensions
@@ -82,7 +82,7 @@ export function useTooltipVisibility(
       return
 
     clearTimeouts()
-    hideTimeout = window.setTimeout(() => {
+    hideTimeout = setTimeout(() => {
       _isVisible.value = false
     }, hideDelay.value)
   }

--- a/src/config/globalConfig.ts
+++ b/src/config/globalConfig.ts
@@ -1,7 +1,7 @@
 import type { TooltipProps, TooltipTheme } from '@/types/tooltip'
 
 import { reactive, ref } from 'vue'
-import { injectThemeStyles } from '../index'
+import { injectThemeStyles } from './themeStyles'
 
 /**
  * Global reactive configuration for tooltips

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -8,3 +8,5 @@ export {
   setTooltipGlobalConfig,
   setTooltipGlobalTheme,
 } from './globalConfig'
+
+export { injectThemeStyles } from './themeStyles'

--- a/src/config/themeStyles.ts
+++ b/src/config/themeStyles.ts
@@ -1,0 +1,57 @@
+import type { TooltipTheme } from '../types/tooltip'
+import { isClient } from '../utils/ssr'
+
+/**
+ * Injects theme styles into the document head
+ *
+ * No-op during SSR - styles are injected once the client takes over.
+ */
+export async function injectThemeStyles(theme: TooltipTheme): Promise<void> {
+  if (!isClient) {
+    return
+  }
+
+  // Default theme uses the component's built-in styles, no CSS injection needed
+  if (theme === 'default') {
+    // Remove any previously injected theme styles to revert to default
+    const oldStyles = document.querySelectorAll('style[data-vct-theme]')
+    oldStyles.forEach(style => style.remove())
+    return
+  }
+
+  // Check if theme styles are already injected
+  const existingStyle = document.querySelector(`style[data-vct-theme="${theme}"]`)
+  if (existingStyle) {
+    return
+  }
+
+  // Remove any previously injected theme styles
+  const oldStyles = document.querySelectorAll('style[data-vct-theme]')
+  oldStyles.forEach(style => style.remove())
+
+  try {
+    // Import the theme CSS dynamically
+    if (theme === 'classic') {
+      await import('../styles/themes/classic.css')
+    }
+    else if (theme === 'primevue') {
+      await import('../styles/themes/primevue.css')
+    }
+    else if (theme === 'vuetify') {
+      await import('../styles/themes/vuetify.css')
+    }
+    else {
+      console.warn(`Unknown theme "${theme}"`)
+      return
+    }
+
+    // Mark that this theme has been loaded
+    const marker = document.createElement('style')
+    marker.setAttribute('data-vct-theme', theme)
+    marker.textContent = `/* Vue Custom Tooltip Theme: ${theme} */`
+    document.head.appendChild(marker)
+  }
+  catch (error) {
+    console.error(`Failed to load theme "${theme}":`, error)
+  }
+}

--- a/src/directives/tooltip.ts
+++ b/src/directives/tooltip.ts
@@ -5,6 +5,7 @@ import type { TooltipDirectiveModifiers } from '@/types/tooltip-modifiers'
 import { createApp, h, reactive } from 'vue'
 import Tooltip from '@/components/tooltip/Tooltip.vue'
 import { getReactiveGlobalConfig } from '@/config/globalConfig'
+import { isClient } from '@/utils/ssr'
 
 export type {
   TooltipDirectiveModifiers,
@@ -159,7 +160,7 @@ function getTooltipProps(binding: TooltipDirectiveBinding): TooltipProps {
  * This is called lazily on first directive mount
  */
 function initializeSharedApp() {
-  if (sharedApp)
+  if (sharedApp || !isClient)
     return
 
   // Create a container for all directive tooltips
@@ -268,6 +269,11 @@ function removeTooltipInstance(element: HTMLElement) {
 }
 
 export const vTooltip: Directive<HTMLElement, string | TooltipProps> = {
+  // Tooltips are client-only, so nothing is added to the server-rendered markup
+  getSSRProps() {
+    return {}
+  },
+
   mounted(element: HTMLElement, binding) {
     if (!binding.value)
       return

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,10 @@ export { Tooltip, TooltipControl, vTooltip }
 export * from './composables'
 
 // Export configuration functions
-export { getTooltipGlobalConfig, getTooltipGlobalTheme, resetTooltipGlobalConfig, setTooltipGlobalConfig, setTooltipGlobalTheme } from './config/index'
+export { getTooltipGlobalConfig, getTooltipGlobalTheme, injectThemeStyles, resetTooltipGlobalConfig, setTooltipGlobalConfig, setTooltipGlobalTheme } from './config/index'
 
 export type { TooltipExposed, TooltipProps, TooltipSlots, TooltipTheme } from './types/tooltip'
+
 // Export types
 export type {
   TooltipDirectiveModifiers,
@@ -24,6 +25,8 @@ export type {
   TooltipTimingModifier,
   TooltipTriggerModifier,
 } from './types/tooltip-modifiers'
+// Export SSR helper for advanced usage
+export { isClient } from './utils/ssr'
 
 /**
  * Options for the VueCustomTooltip plugin
@@ -52,58 +55,6 @@ export interface VueCustomTooltipOptions {
   directiveName?: string
 }
 
-/**
- * Injects theme styles into the document head
- */
-async function injectThemeStyles(theme: TooltipTheme): Promise<void> {
-  // Default theme uses the component's built-in styles, no CSS injection needed
-  if (theme === 'default') {
-    // Remove any previously injected theme styles to revert to default
-    const oldStyles = document.querySelectorAll('style[data-vct-theme]')
-    oldStyles.forEach(style => style.remove())
-    return
-  }
-
-  // Check if theme styles are already injected
-  const existingStyle = document.querySelector(`style[data-vct-theme="${theme}"]`)
-  if (existingStyle) {
-    return
-  }
-
-  // Remove any previously injected theme styles
-  const oldStyles = document.querySelectorAll('style[data-vct-theme]')
-  oldStyles.forEach(style => style.remove())
-
-  try {
-    // Import the theme CSS dynamically
-    if (theme === 'classic') {
-      await import('./styles/themes/classic.css')
-    }
-    else if (theme === 'primevue') {
-      await import('./styles/themes/primevue.css')
-    }
-    else if (theme === 'vuetify') {
-      await import('./styles/themes/vuetify.css')
-    }
-    else {
-      console.warn(`Unknown theme "${theme}"`)
-      return
-    }
-
-    // Mark that this theme has been loaded
-    const marker = document.createElement('style')
-    marker.setAttribute('data-vct-theme', theme)
-    marker.textContent = `/* Vue Custom Tooltip Theme: ${theme} */`
-    document.head.appendChild(marker)
-  }
-  catch (error) {
-    console.error(`Failed to load theme "${theme}":`, error)
-  }
-}
-
-// Export theme CSS injector for runtime theme switching
-export { injectThemeStyles }
-
 // Vue plugin for easy installation
 export const VueCustomTooltip: Plugin = {
   install(app: App, options?: VueCustomTooltipOptions) {
@@ -117,13 +68,9 @@ export const VueCustomTooltip: Plugin = {
       setTooltipGlobalConfig(options.globalConfig)
     }
 
-    // Apply theme if provided
+    // Apply theme if provided - style injection is a no-op during SSR
     if (options?.theme) {
-      setTooltipGlobalTheme(options.theme)
-      // Inject theme styles
-      if (typeof document !== 'undefined') {
-        injectThemeStyles(options.theme)
-      }
+      void setTooltipGlobalTheme(options.theme)
     }
   },
 }

--- a/src/utils/ssr.ts
+++ b/src/utils/ssr.ts
@@ -1,0 +1,5 @@
+/**
+ * Whether the code is currently running in a browser environment.
+ * Used to keep the library safe under SSR (Nuxt, vite-ssr, ...).
+ */
+export const isClient: boolean = typeof window !== 'undefined' && typeof document !== 'undefined'

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -15,7 +15,8 @@
     "src/directives/tooltip.ts",
     "src/config/**/*.ts",
     "src/composables/**/*.ts",
-    "src/types/**/*.ts"
+    "src/types/**/*.ts",
+    "src/utils/**/*.ts"
   ],
   "exclude": [
     "src/**/*.spec.ts",


### PR DESCRIPTION
### Added

- **SSR Support**: The package is now fully server-side rendering safe and can be used in Nuxt and other Vue SSR setups without `document is not defined` errors
- **`isClient` Export**: New exported flag to detect a browser environment from consuming code
- **Docs**: New "SSR & Nuxt" guide page
- **Package Exports**: Added the shorter `@borstihd/vue-custom-tooltip/style.css` entry (the previous `/dist/style.css` path keeps working)

### Fixed

- **Theme Injection**: `injectThemeStyles()` and `setTooltipGlobalTheme()` no longer touch `document` during SSR; styles are injected once the client takes over
- **Teleport**: The tooltip teleport is only rendered after mount, preventing SSR errors and hydration mismatches
- **Hydration**: Tooltip ARIA IDs now use Vue's `useId()` instead of `Math.random()`, so server and client markup match
- **Directive**: `v-tooltip` provides `getSSRProps` and guards its shared app initialization against non-browser environments
- **Positioning**: `window` access in position calculation and show/hide timers is guarded for non-browser environments

### Changed

- **Internal**: `injectThemeStyles()` moved into its own module to resolve a circular import between the entry point and the global config (still exported from the package root)
- **Package**: Declared `sideEffects` so bundlers can tree-shake more aggressively while keeping CSS imports intact